### PR TITLE
I11 Add streamflow networks to map

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -9,6 +9,7 @@ import React, {useState} from 'react'
 function App() {
   const [currentRegionName, setCurrentRegionName] = useState(null);
   const [currentRegionBoundary, setCurrentRegionBoundary] = useState(null);
+  const [currentWatershedMouth, setCurrentWatershedMouth] = useState(null);
   
   function setRegionName(event) {
       setCurrentRegionName(event);
@@ -16,6 +17,10 @@ function App() {
   
   function setRegionBoundary(event) {
       setCurrentRegionBoundary(event);
+  }
+
+  function setWatershedMouth(event) {
+      setCurrentWatershedMouth(event);
   }
 
   return (
@@ -27,10 +32,12 @@ function App() {
             <Col lg={6} md={6}>
               <MapDisplay
                 currentRegionBoundary={currentRegionBoundary}
+                currentWatershedMouth={currentWatershedMouth}
               />
               <AreaDisplay
                 onChangeRegionName={setRegionName}
                 onChangeRegionBoundary={setRegionBoundary}
+                onChangeWatershedMouth={setWatershedMouth}
               />
             </Col>
             <Col lg={6} md={6}>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -9,7 +9,7 @@ import React, {useState} from 'react'
 function App() {
   const [currentRegionName, setCurrentRegionName] = useState(null);
   const [currentRegionBoundary, setCurrentRegionBoundary] = useState(null);
-  const [currentWatershedMouth, setCurrentWatershedMouth] = useState(null);
+  const [currentWatershedStreams, setCurrentWatershedStreams] = useState(null);
   
   function setRegionName(event) {
       setCurrentRegionName(event);
@@ -20,7 +20,7 @@ function App() {
   }
 
   function setWatershedMouth(event) {
-      setCurrentWatershedMouth(event);
+      setCurrentWatershedStreams(event);
   }
 
   return (
@@ -32,7 +32,7 @@ function App() {
             <Col lg={6} md={6}>
               <MapDisplay
                 currentRegionBoundary={currentRegionBoundary}
-                currentWatershedMouth={currentWatershedMouth}
+                currentWatershedStreams={currentWatershedStreams}
               />
               <AreaDisplay
                 onChangeRegionName={setRegionName}

--- a/src/components/AreaDisplay/AreaDisplay.js
+++ b/src/components/AreaDisplay/AreaDisplay.js
@@ -11,7 +11,8 @@ function AreaDisplay({onChangeRegionName, onChangeRegionBoundary, onChangeWaters
   const [currentRegionBoundary, setCurrentRegionBoundary] = useState(null);
   const [regionAreas, setRegionAreas] = useState();
   const [currentRegionArea, setCurrentRegionArea] = useState();
-  const [currentWatershedStreams, setCurrentWatershedStreams] = useState();
+  const [watershedStreams, setWatershedStreams] = useState([]);
+  const [currentWatershedStreams, setCurrentWatershedStreams] = useState(null);
 
   //fetch region list from geoserver if we don't already have it.
   if (regionNames.length === 0){
@@ -20,9 +21,15 @@ function AreaDisplay({onChangeRegionName, onChangeRegionBoundary, onChangeWaters
             var names = [];
             var boundaries = [];
             var areas = [];
+            var streams = [];
             for (const feature of data.features){
                 names.push(feature.properties.WTRSHDGRPN);
                 boundaries.push(feature.geometry);
+
+                if(feature.properties.OUTLET === ""){
+                  streams.push(null);
+                }
+                else streams.push(JSON.parse(feature.properties.OUTLET));
                 
                 let area = feature.properties.AREA_SQM;
                 if (typeof(area) === 'number'){
@@ -36,6 +43,7 @@ function AreaDisplay({onChangeRegionName, onChangeRegionBoundary, onChangeWaters
             setRegionNames(names);
             setRegionBoundaries(boundaries);
             setRegionAreas(areas);
+            setWatershedStreams(streams);
         }
     );
   }
@@ -47,9 +55,10 @@ function AreaDisplay({onChangeRegionName, onChangeRegionBoundary, onChangeWaters
       setCurrentRegionBoundary(boundary);
       onChangeRegionBoundary(boundary);
 
-      setCurrentWatershedStreams({"type": "Point", "coordinates": [-120.0, 53.2]});
-      onChangeWatershedMouth({"type": "Point", "coordinates": [-120.0, 53.2]});
-      
+      const mouth = watershedStreams[findIndex(regionNames, (n) => {return n == event.value;})];
+      setCurrentWatershedStreams(mouth);
+      onChangeWatershedMouth(mouth);
+
       setCurrentRegionArea(regionAreas[findIndex(regionNames, (n) => {return n == event.value;})]);
   };
     

--- a/src/components/AreaDisplay/AreaDisplay.js
+++ b/src/components/AreaDisplay/AreaDisplay.js
@@ -11,7 +11,7 @@ function AreaDisplay({onChangeRegionName, onChangeRegionBoundary, onChangeWaters
   const [currentRegionBoundary, setCurrentRegionBoundary] = useState(null);
   const [regionAreas, setRegionAreas] = useState();
   const [currentRegionArea, setCurrentRegionArea] = useState();
-  const [currentWatershedMouth, setCurrentWatershedMouth] = useState();
+  const [currentWatershedStreams, setCurrentWatershedStreams] = useState();
 
   //fetch region list from geoserver if we don't already have it.
   if (regionNames.length === 0){
@@ -47,8 +47,8 @@ function AreaDisplay({onChangeRegionName, onChangeRegionBoundary, onChangeWaters
       setCurrentRegionBoundary(boundary);
       onChangeRegionBoundary(boundary);
 
-      setCurrentWatershedMouth({"type": "Point", "coordinates": [-126.1, 53.9]});
-      onChangeWatershedMouth({"type": "Point", "coordinates": [-126.1, 53.9]});
+      setCurrentWatershedStreams({"type": "Point", "coordinates": [-120.0, 53.2]});
+      onChangeWatershedMouth({"type": "Point", "coordinates": [-120.0, 53.2]});
       
       setCurrentRegionArea(regionAreas[findIndex(regionNames, (n) => {return n == event.value;})]);
   };

--- a/src/components/AreaDisplay/AreaDisplay.js
+++ b/src/components/AreaDisplay/AreaDisplay.js
@@ -3,7 +3,7 @@ import AreaSelector from '../AreaSelector/AreaSelector.js'
 import React, {useState} from 'react';
 import {findIndex} from 'lodash';
 
-function AreaDisplay({onChangeRegionName, onChangeRegionBoundary}) {
+function AreaDisplay({onChangeRegionName, onChangeRegionBoundary, onChangeWatershedMouth}) {
 
   const [regionNames, setRegionNames] = useState([]);
   const [regionBoundaries, setRegionBoundaries] = useState([]);
@@ -11,6 +11,7 @@ function AreaDisplay({onChangeRegionName, onChangeRegionBoundary}) {
   const [currentRegionBoundary, setCurrentRegionBoundary] = useState(null);
   const [regionAreas, setRegionAreas] = useState();
   const [currentRegionArea, setCurrentRegionArea] = useState();
+  const [currentWatershedMouth, setCurrentWatershedMouth] = useState();
 
   //fetch region list from geoserver if we don't already have it.
   if (regionNames.length === 0){
@@ -45,6 +46,9 @@ function AreaDisplay({onChangeRegionName, onChangeRegionBoundary}) {
       const boundary = regionBoundaries[findIndex(regionNames, (n) => {return n == event.value;})];
       setCurrentRegionBoundary(boundary);
       onChangeRegionBoundary(boundary);
+
+      setCurrentWatershedMouth({"type": "Point", "coordinates": [-126.1, 53.9]});
+      onChangeWatershedMouth({"type": "Point", "coordinates": [-126.1, 53.9]});
       
       setCurrentRegionArea(regionAreas[findIndex(regionNames, (n) => {return n == event.value;})]);
   };

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -2,18 +2,20 @@ import { BCBaseMap, SetView } from 'pcic-react-leaflet-components';
 import SimpleGeoJSON from '../SimpleGeoJSON/SimpleGeoJSON.js';
 import { WMSTileLayer } from 'react-leaflet';
 
-function DataMap({currentRegionBoundary, currentWatershedMouth}) {
+function DataMap({currentRegionBoundary, currentWatershedStreams}) {
+  /*if(currentRegionBoundary){
+    alert(currentRegionBoundary.coordinates)
+  }*/
   const viewport = BCBaseMap.initialViewport;
-
   //convert the geoJSON to a Feature so it can be displayed on the map.
   const boundaryFeature = currentRegionBoundary ? {
       type: "Feature",
       geometry: currentRegionBoundary
   } : {};
 
-  const watershedMouth = currentWatershedMouth ? {
+  const watershedMouth = currentWatershedStreams ? {
       type: "Feature",
-      geometry: currentWatershedMouth
+      geometry: currentWatershedStreams.streams.geometry
   } : {};
   
   const featureCollection = (boundaryFeature.geometry && watershedMouth.geometry) ? {
@@ -29,7 +31,8 @@ function DataMap({currentRegionBoundary, currentWatershedMouth}) {
           center={viewport.center}
         >
           <SetView view={viewport}/>
-          <SimpleGeoJSON data={boundaryFeature} fill={true}/>
+          <SimpleGeoJSON data={boundaryFeature} fill={false}/>
+          <SimpleGeoJSON data={watershedMouth} fill={false}/>
           <WMSTileLayer
             url={"https://services.pacificclimate.org/ncwms"}
             format={'image/png'}

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -2,7 +2,7 @@ import { BCBaseMap, SetView } from 'pcic-react-leaflet-components';
 import SimpleGeoJSON from '../SimpleGeoJSON/SimpleGeoJSON.js';
 import { WMSTileLayer } from 'react-leaflet';
 
-function DataMap({currentRegionBoundary, currentWatershedStreams}) {
+function DataMap({currentRegionBoundary, currentWatershedStreams, currentDownstream}) {
   const viewport = BCBaseMap.initialViewport;
   //convert the geoJSON to a Feature so it can be displayed on the map.
   const boundaryFeature = currentRegionBoundary ? {
@@ -20,6 +20,15 @@ function DataMap({currentRegionBoundary, currentWatershedStreams}) {
     features: [boundaryFeature, watershedMouth]
   } : {};
 
+  const downstream = currentDownstream ? {
+      type: "Feature",
+      properties: {test: "test"},
+      geometry: {
+          type: "LineString",
+          coordinates: currentDownstream.boundary.geometry.coordinates
+      }
+  } : {};
+
   return (
     <div className="DataMap">
         <BCBaseMap
@@ -28,8 +37,9 @@ function DataMap({currentRegionBoundary, currentWatershedStreams}) {
           center={viewport.center}
         >
           <SetView view={viewport}/>
-          <SimpleGeoJSON data={boundaryFeature} fill={false}/>
-          <SimpleGeoJSON data={watershedMouth} fill={false}/>
+          <SimpleGeoJSON data={boundaryFeature} fill={false} color="#ffffff"/>
+          <SimpleGeoJSON data={watershedMouth} fill={false} color="#6699FF"/>
+          <SimpleGeoJSON data={downstream} fill={false} color="#6699FF"/>
           <WMSTileLayer
             url={"https://services.pacificclimate.org/ncwms"}
             format={'image/png'}

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -3,9 +3,6 @@ import SimpleGeoJSON from '../SimpleGeoJSON/SimpleGeoJSON.js';
 import { WMSTileLayer } from 'react-leaflet';
 
 function DataMap({currentRegionBoundary, currentWatershedStreams}) {
-  /*if(currentRegionBoundary){
-    alert(currentRegionBoundary.coordinates)
-  }*/
   const viewport = BCBaseMap.initialViewport;
   //convert the geoJSON to a Feature so it can be displayed on the map.
   const boundaryFeature = currentRegionBoundary ? {

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -2,7 +2,7 @@ import { BCBaseMap, SetView } from 'pcic-react-leaflet-components';
 import SimpleGeoJSON from '../SimpleGeoJSON/SimpleGeoJSON.js';
 import { WMSTileLayer } from 'react-leaflet';
 
-function DataMap({currentRegionBoundary}) {
+function DataMap({currentRegionBoundary, currentWatershedMouth}) {
   const viewport = BCBaseMap.initialViewport;
 
   //convert the geoJSON to a Feature so it can be displayed on the map.
@@ -10,7 +10,17 @@ function DataMap({currentRegionBoundary}) {
       type: "Feature",
       geometry: currentRegionBoundary
   } : {};
-    
+
+  const watershedMouth = currentWatershedMouth ? {
+      type: "Feature",
+      geometry: currentWatershedMouth
+  } : {};
+  
+  const featureCollection = (boundaryFeature.geometry && watershedMouth.geometry) ? {
+    type: "FeatureCollection",
+    features: [boundaryFeature, watershedMouth]
+  } : {};
+
   return (
     <div className="DataMap">
         <BCBaseMap
@@ -19,7 +29,7 @@ function DataMap({currentRegionBoundary}) {
           center={viewport.center}
         >
           <SetView view={viewport}/>
-          <SimpleGeoJSON data={boundaryFeature} fill={false}/>
+          <SimpleGeoJSON data={boundaryFeature} fill={true}/>
           <WMSTileLayer
             url={"https://services.pacificclimate.org/ncwms"}
             format={'image/png'}

--- a/src/components/LongTermAverageGraph/LongTermAverageGraph.js
+++ b/src/components/LongTermAverageGraph/LongTermAverageGraph.js
@@ -18,15 +18,15 @@ function LongTermAverageGraph({longTermData}) {
     var dataArray = entries(longTermData);
     var data = [];
     var graphTitle =  `Mean Long Term Maximum Temperature: ${ 
-        dataArray.length >= 1 ? (dataArray[0].length == 2 ? dataArray[0][0].toUpperCase() : "") : ""
+        dataArray.length >= 1 ? (dataArray[0].length === 2 ? dataArray[0][0].toUpperCase() : "") : ""
     }`;
     var yAxisTitle = `Mean Maximum Temperature (${
-        dataArray.length >= 1 ? (dataArray[0].length == 2 ? dataArray[0][1].units : "") : ""
+        dataArray.length >= 1 ? (dataArray[0].length === 2 ? dataArray[0][1].units : "") : ""
     })`;
     
     // Assert that longTermData is formatted as expected
     if (dataArray.length >= 1) {
-        if (dataArray[0].length == 2){
+        if (dataArray[0].length === 2){
             data = dataArray[0][1].data;
         }
     }

--- a/src/components/MapDisplay/MapDisplay.js
+++ b/src/components/MapDisplay/MapDisplay.js
@@ -9,13 +9,15 @@ function MapDisplay({currentRegionBoundary, currentWatershedStreams}) {
   const [prevStreams, setPrevStreams] = useState(null);
   
   if(prevStreams !== currentWatershedStreams){ 
-    getWatershedStreams(currentWatershedStreams).then(data => {
-        setWatershedStreams(data);
-        }
-    );
-    /*if(watershedStreams){
-      alert(watershedStreams.streams.geometry.coordinates);
-    }*/
+    if (currentWatershedStreams === null) {
+      setWatershedStreams("");
+    }
+    else{
+      getWatershedStreams(currentWatershedStreams).then(data => {
+          setWatershedStreams(data);
+          }
+      );
+    }
     setPrevStreams(currentWatershedStreams);
   }
 

--- a/src/components/MapDisplay/MapDisplay.js
+++ b/src/components/MapDisplay/MapDisplay.js
@@ -4,7 +4,7 @@ import DataMap from '../DataMap/DataMap.js'
 function MapDisplay({currentRegionBoundary, currentWatershedMouth}) {
   return (
     <div className="MapDisplay">
-        {currentWatershedMouth ? currentWatershedMouth.coordinates : "no coordinates"}
+        {currentWatershedMouth ? `${currentWatershedMouth.coordinates[0]} , ${currentWatershedMouth.coordinates[1]}` : "no coordinates"}
         <DataMap
           currentRegionBoundary={currentRegionBoundary}
           currentWatershedMouth={currentWatershedMouth}

--- a/src/components/MapDisplay/MapDisplay.js
+++ b/src/components/MapDisplay/MapDisplay.js
@@ -1,13 +1,14 @@
 import './MapDisplay.css';
 import DataMap from '../DataMap/DataMap.js'
-import {getWatershedStreams} from '../../data-services/pcex-backend.js'
+import {getWatershedStreams, getDownstream} from '../../data-services/pcex-backend.js'
 import React, {useState} from 'react';
 
 function MapDisplay({currentRegionBoundary, currentWatershedStreams}) {
   
   const [watershedStreams, setWatershedStreams] = useState(null);
+  const [downstream, setDownstream] = useState(null);
   const [prevStreams, setPrevStreams] = useState(null);
-  
+
   if(prevStreams !== currentWatershedStreams){ 
     if (currentWatershedStreams === null) {
       setWatershedStreams("");
@@ -17,6 +18,9 @@ function MapDisplay({currentRegionBoundary, currentWatershedStreams}) {
           setWatershedStreams(data);
           }
       );
+      getDownstream(currentWatershedStreams).then(data => {
+          setDownstream(data);
+      });
     }
     setPrevStreams(currentWatershedStreams);
   }
@@ -26,6 +30,7 @@ function MapDisplay({currentRegionBoundary, currentWatershedStreams}) {
         <DataMap
           currentRegionBoundary={currentRegionBoundary}
           currentWatershedStreams={watershedStreams}
+          currentDownstream={downstream}
         />
     </div>
   );

--- a/src/components/MapDisplay/MapDisplay.js
+++ b/src/components/MapDisplay/MapDisplay.js
@@ -1,13 +1,29 @@
 import './MapDisplay.css';
 import DataMap from '../DataMap/DataMap.js'
+import {getWatershedStreams} from '../../data-services/pcex-backend.js'
+import React, {useState} from 'react';
 
-function MapDisplay({currentRegionBoundary, currentWatershedMouth}) {
+function MapDisplay({currentRegionBoundary, currentWatershedStreams}) {
+  
+  const [watershedStreams, setWatershedStreams] = useState(null);
+  const [prevStreams, setPrevStreams] = useState(null);
+  
+  if(prevStreams !== currentWatershedStreams){ 
+    getWatershedStreams(currentWatershedStreams).then(data => {
+        setWatershedStreams(data);
+        }
+    );
+    /*if(watershedStreams){
+      alert(watershedStreams.streams.geometry.coordinates);
+    }*/
+    setPrevStreams(currentWatershedStreams);
+  }
+
   return (
     <div className="MapDisplay">
-        {currentWatershedMouth ? `${currentWatershedMouth.coordinates[0]} , ${currentWatershedMouth.coordinates[1]}` : "no coordinates"}
         <DataMap
           currentRegionBoundary={currentRegionBoundary}
-          currentWatershedMouth={currentWatershedMouth}
+          currentWatershedStreams={watershedStreams}
         />
     </div>
   );

--- a/src/components/MapDisplay/MapDisplay.js
+++ b/src/components/MapDisplay/MapDisplay.js
@@ -1,11 +1,13 @@
 import './MapDisplay.css';
 import DataMap from '../DataMap/DataMap.js'
 
-function MapDisplay({currentRegionBoundary}) {
+function MapDisplay({currentRegionBoundary, currentWatershedMouth}) {
   return (
     <div className="MapDisplay">
+        {currentWatershedMouth ? currentWatershedMouth.coordinates : "no coordinates"}
         <DataMap
           currentRegionBoundary={currentRegionBoundary}
+          currentWatershedMouth={currentWatershedMouth}
         />
     </div>
   );

--- a/src/components/SimpleGeoJSON/SimpleGeoJSON.js
+++ b/src/components/SimpleGeoJSON/SimpleGeoJSON.js
@@ -27,6 +27,7 @@ function GeoJSONFeature({ feature, ...rest }) {
     Polygon: Polygon,
     MultiPolygon: Polygon,
     MultiLineString: Polyline,
+    LineString: Polyline
   };
   const Component = geometryType2Component[feature.geometry.type];
   if (!Component) {
@@ -52,6 +53,9 @@ function geoJSON2Layers(geoJSON, rest) {
     case 'FeatureCollection':
       console.log('geoJSON2Layers: FeatureCollection');
       return geoJSON.features.map(geoJSON2Layers);
+    case 'LineString':
+        console.log('geoJSON2Layers: LineString');
+        return <GeoJSONPolyLine polyline={geoJSON} {...rest}/>;
     default:
       console.log('geoJSON2Layers: unknown', geoJSON && geoJSON.type);
       return null;

--- a/src/components/SimpleGeoJSON/SimpleGeoJSON.js
+++ b/src/components/SimpleGeoJSON/SimpleGeoJSON.js
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Polygon } from 'react-leaflet';
+import { Polygon, Polyline } from 'react-leaflet';
 import isArray from 'lodash/fp/isArray';
 
 
@@ -26,6 +26,7 @@ function GeoJSONFeature({ feature, ...rest }) {
   const geometryType2Component = {
     Polygon: Polygon,
     MultiPolygon: Polygon,
+    MultiLineString: Polyline,
   };
   const Component = geometryType2Component[feature.geometry.type];
   if (!Component) {

--- a/src/data-services/pcex-backend.js
+++ b/src/data-services/pcex-backend.js
@@ -19,6 +19,9 @@ function geoJSONtoWKT(area) {
         });
         wkt = wkt.concat("))");
     }
+    else if (area.type === "Point"){
+        wkt = `POINT (${area.coordinates[0]} ${area.coordinates[1]})`
+    }
     else{
         console.log("other conversions not implemented yet.");
         wkt = ""
@@ -61,6 +64,21 @@ export function testLongTermAverageDataRequest(area) {
                 timescale: "monthly",
                 time: "5",
                 area: geoJSONtoWKT(area),
+            }
+        }
+    )
+    .then(response => response.data);
+}
+
+export function getWatershedStreams(point) {
+    // accepts only a specified point, gets data from the same
+    // set of files
+    return axios.get(
+    process.env.REACT_APP_PCEX_API_URL + "/streamflow/watershed_streams",
+        {
+            params: {
+                station: geoJSONtoWKT(point),
+                ensemble_name: "fraser_watershed"
             }
         }
     )

--- a/src/data-services/pcex-backend.js
+++ b/src/data-services/pcex-backend.js
@@ -84,3 +84,18 @@ export function getWatershedStreams(point) {
     )
     .then(response => response.data);
 }
+
+export function getDownstream(point) {
+    // accepts only a specified point, gets data from the same
+    // set of files
+    return axios.get(
+    process.env.REACT_APP_PCEX_DEV_API_URL + "/streamflow/downstream",
+        {
+            params: {
+                station: geoJSONtoWKT(point),
+                ensemble_name: "upper_fraser_watershed"
+            }
+        }
+    )
+    .then(response => response.data);
+}

--- a/src/data-services/pcex-backend.js
+++ b/src/data-services/pcex-backend.js
@@ -74,11 +74,11 @@ export function getWatershedStreams(point) {
     // accepts only a specified point, gets data from the same
     // set of files
     return axios.get(
-    process.env.REACT_APP_PCEX_API_URL + "/streamflow/watershed_streams",
+    process.env.REACT_APP_PCEX_DEV_API_URL + "/streamflow/watershed_streams",
         {
             params: {
                 station: geoJSONtoWKT(point),
-                ensemble_name: "fraser_watershed"
+                ensemble_name: "upper_fraser_watershed"
             }
         }
     )


### PR DESCRIPTION
This branch accesses the new `watershed-streams` API and uses it to draw connectivity associated with a given watershed. It reads an "outlet" value from the watershed files when present, and uses that to query the API for stream connectivity within the watershed.

Streams aren't an exact match for the watershed (see image) because watersheds are defined differently by the BC Freshwater Atlas and the RVIC routing model

1. RVIC defines a watershed as all grid squares upstream of a selected point, but the Freshwater Atlas often defines a single river as multuplke watersheds. For example, the Upper Chilako is upstream of the Lower Chilako, but not considered part of the Lower Chilako watershed.

2. RVIC is lower resolution than the BC Freshwater Atlas

Here's the Lower Chilako. You can see a lot of the streams go outside the boundary of the watershed. I need to talk to hydrologists and find it if we'd like to trim the streams at the official boundary, as laid out by the BC Freshwater Atlas.
![streams](https://user-images.githubusercontent.com/4512605/167961232-2d53f41d-a479-43d2-b3ee-e6ca54b40b8f.png)

Minor functional changes to make before merging:

- [x] add the downstream API call to the map as well
- [x] make the streams and watershed boundary different colours
- [ ] mark the outlet? Ask @mschnorb if this would be useful.
- [ ] currently, due to rasterio issues, this frontend requires two different backends. Resolve those issues and make all PCEX API calls against a single backend
- [ ] clip streams to watershed? Ask @mschnorb if this would be useful